### PR TITLE
Resolve computed #include directives via SimplePreprocessor

### DIFF
--- a/src/compiletools/file_analyzer.py
+++ b/src/compiletools/file_analyzer.py
@@ -269,6 +269,9 @@ def parse_directive_struct(
             else:
                 directive.macro_value = None
 
+    elif dtype == "include":
+        directive.condition = strip_sz(content_slice)
+
     elif dtype == "pragma":
         # Extract pragma name (e.g., "once" from "#pragma once")
         directive.macro_name = strip_sz(content_slice)
@@ -907,7 +910,7 @@ def _extract_conditional_macros(directives: list[PreprocessorDirective]) -> froz
         if directive.directive_type in ("ifdef", "ifndef"):
             if directive.macro_name:
                 macros.add(directive.macro_name)
-        elif directive.directive_type in ("if", "elif"):
+        elif directive.directive_type in ("if", "elif", "include"):
             if directive.condition:
                 # Extract identifiers from condition using stringzilla
                 cond = directive.condition

--- a/src/compiletools/headerdeps.py
+++ b/src/compiletools/headerdeps.py
@@ -380,12 +380,9 @@ class DirectHeaderDeps(HeaderDepsBase):
 
             # Cache miss for invariant file - compute and store
             result = get_or_compute_preprocessing(analysis_result, self.defined_macros, self.args.verbose)
-            active_line_set = set(result.active_lines)
 
             include_list = [
-                sz.Str(inc["filename"])
-                for inc in analysis_result.includes
-                if inc["line_num"] in active_line_set and not inc["is_commented"]
+                sz.Str(inc["filename"]) for inc in result.active_includes if not inc.get("is_commented", False)
             ]
 
             self.defined_macros = result.updated_macros
@@ -412,13 +409,8 @@ class DirectHeaderDeps(HeaderDepsBase):
             )
 
         result = get_or_compute_preprocessing(analysis_result, self.defined_macros, self.args.verbose)
-        active_line_set = set(result.active_lines)
 
-        include_list = [
-            sz.Str(inc["filename"])
-            for inc in analysis_result.includes
-            if inc["line_num"] in active_line_set and not inc["is_commented"]
-        ]
+        include_list = [sz.Str(inc["filename"]) for inc in result.active_includes if not inc.get("is_commented", False)]
 
         self.defined_macros = result.updated_macros
         _include_list_cache[cache_key] = (include_list, result.file_defines, result.file_undefs)

--- a/src/compiletools/preprocessing_cache.py
+++ b/src/compiletools/preprocessing_cache.py
@@ -428,6 +428,20 @@ def get_or_compute_preprocessing(file_result, input_macros: "MacroState", verbos
         if inc["line_num"] in active_line_set:
             active_includes.append(inc)
 
+    # Resolve computed includes from directives
+    for directive in file_result.directives:
+        if directive.directive_type == "include" and directive.line_num in active_line_set and directive.condition:
+            resolved = preprocessor.resolve_computed_include(directive.condition)
+            if resolved:
+                active_includes.append(
+                    {
+                        "line_num": directive.line_num,
+                        "filename": sz.Str(resolved),
+                        "is_system": False,
+                        "is_commented": False,
+                    }
+                )
+
     # Extract active magic flags
     active_magic_flags = []
     for magic in file_result.magic_flags:

--- a/src/compiletools/samples/computed_include/default_extra.h
+++ b/src/compiletools/samples/computed_include/default_extra.h
@@ -1,0 +1,2 @@
+#pragma once
+void default_func();

--- a/src/compiletools/samples/computed_include/linux_extra.h
+++ b/src/compiletools/samples/computed_include/linux_extra.h
@@ -1,0 +1,2 @@
+#pragma once
+void linux_extra_func();

--- a/src/compiletools/samples/computed_include/main.cpp
+++ b/src/compiletools/samples/computed_include/main.cpp
@@ -1,0 +1,10 @@
+#define XSTR(x) STR(x)
+#define STR(x) #x
+
+#ifdef COMPILETIME_INCLUDE_FILE
+#include XSTR(COMPILETIME_INCLUDE_FILE)
+#else
+#include "default_extra.h"
+#endif
+
+int main() { return 0; }

--- a/src/compiletools/samples/computed_include/windows_extra.h
+++ b/src/compiletools/samples/computed_include/windows_extra.h
@@ -1,0 +1,2 @@
+#pragma once
+void windows_extra_func();

--- a/src/compiletools/test_findtargets.py
+++ b/src/compiletools/test_findtargets.py
@@ -52,6 +52,7 @@ class TestFindTargetsModule:
             "transitive_cache_bug/engine/b-game.cpp",
             "header_guard_bug/main.cpp",
             "undef_bug/main.cpp",
+            "computed_include/main.cpp",
         }
         relativeexpectedtests = {
             "cross_platform/test_source.cpp",

--- a/src/compiletools/test_headerdeps.py
+++ b/src/compiletools/test_headerdeps.py
@@ -383,3 +383,33 @@ class TestHeaderDepsModule(tb.BaseCompileToolsTestCase):
 
             # This should not raise an exception - the isystem parsing should work
             compiletools.headerdeps.DirectHeaderDeps(args)
+
+    def test_computed_include_no_macro(self):
+        """Without COMPILETIME_INCLUDE_FILE, the #else branch includes default_extra.h."""
+        filename = self._get_sample_path("computed_include/main.cpp")
+        result_set = uth.headerdeps_result(filename, "direct")
+        expected = self._get_sample_path("computed_include/default_extra.h")
+        assert expected in result_set, f"Expected {expected} in {result_set}"
+
+    def test_computed_include_with_commandline_macro(self):
+        """With -DCOMPILETME_INCLUDE_FILE=linux_extra.h, direct should find linux_extra.h."""
+        filename = self._get_sample_path("computed_include/main.cpp")
+        result_set = uth.headerdeps_result(
+            filename,
+            "direct",
+            cppflags="-DCOMPILETIME_INCLUDE_FILE=linux_extra.h",
+        )
+        expected = self._get_sample_path("computed_include/linux_extra.h")
+        assert expected in result_set, f"Expected {expected} in {result_set}"
+
+    @uth.requires_functional_compiler
+    def test_computed_include_with_commandline_macro_cpp(self):
+        """With -DCOMPILETME_INCLUDE_FILE=linux_extra.h, cpp preprocessor should resolve it."""
+        filename = self._get_sample_path("computed_include/main.cpp")
+        result_set = uth.headerdeps_result(
+            filename,
+            "cpp",
+            cppflags="-DCOMPILETIME_INCLUDE_FILE=linux_extra.h",
+        )
+        expected = self._get_sample_path("computed_include/linux_extra.h")
+        assert expected in result_set, f"Expected {expected} in {result_set}"


### PR DESCRIPTION
## Summary

Fixes #8. Adds support for computed `#include` directives (e.g. `#include XSTR(COMPILETIME_INCLUDE_FILE)`) in `direct` headerdeps mode.

- Store include argument in `PreprocessorDirective` during `parse_directive_struct()` and add `include` to `_extract_conditional_macros()` for cache correctness
- Add `resolve_computed_include()` to `SimplePreprocessor` that strips function-like macro wrappers and expands macros
- Resolve computed includes when building `active_includes` in `preprocessing_cache.py`
- Simplify `_create_include_list()` in `headerdeps.py` to use `result.active_includes` (net code reduction)

## Test plan

- [x] 3 new computed include tests pass (`test_computed_include_no_macro`, `test_computed_include_with_commandline_macro`, `test_computed_include_with_commandline_macro_cpp`)
- [x] All 20 headerdeps tests pass
- [x] Full test suite passes (423 passed, 2 skipped)
- [x] Performance profiling vs v7.0.2 shows no regression (25.6% faster overall in direct mode)